### PR TITLE
fixed some statement for just one day workshop

### DIFF
--- a/index.md
+++ b/index.md
@@ -33,8 +33,8 @@ eventbrite:           # optional: alphanumeric key for Eventbrite registration, 
 <p>
   Space is limited to 24 participants for this workshop
   and registration is required. A fee of $46.00 will 
-  be charged and lunch will be provided both days. 
-  Please plan on attending the entire time for both days.
+  be charged and lunch will be provided. Please note that this is only one day workshop,
+  and plan accordingly.
   You can register in UF's conference system here:
 </p>
 


### PR DESCRIPTION
The old version saying it's two-day workshop, and rephrased it as one day. Does anyone concern about registration fee of $46.00 for just one day?

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
